### PR TITLE
storybook7の書き方でstoryを書き直す

### DIFF
--- a/src/components/atoms/SearchTargetLabel.stories.tsx
+++ b/src/components/atoms/SearchTargetLabel.stories.tsx
@@ -1,9 +1,8 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SearchTargetLabel } from './SearchTargetLabel';
 
-const componentMeta: ComponentMeta<typeof SearchTargetLabel> = {
+const meta: Meta<typeof SearchTargetLabel> = {
   title: 'Atoms/SearchTargetLabel',
   component: SearchTargetLabel,
   argTypes: {
@@ -11,14 +10,13 @@ const componentMeta: ComponentMeta<typeof SearchTargetLabel> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof SearchTargetLabel> = (args) => (
-  <SearchTargetLabel {...args} />
-);
+type Story = StoryObj<typeof SearchTargetLabel>;
 
-export const Label = Template.bind({});
-Label.args = {
-  label: '名前',
-  sx: {},
+export const Label: Story = {
+  args: {
+    label: '名前',
+    sx: {},
+  },
 };

--- a/src/components/atoms/SearchWord.stories.tsx
+++ b/src/components/atoms/SearchWord.stories.tsx
@@ -1,9 +1,8 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SearchWord } from './SearchWord';
 
-const componentMeta: ComponentMeta<typeof SearchWord> = {
+const meta: Meta<typeof SearchWord> = {
   title: 'Atoms/SearchWord',
   component: SearchWord,
   argTypes: {
@@ -11,20 +10,19 @@ const componentMeta: ComponentMeta<typeof SearchWord> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof SearchWord> = (args) => (
-  <SearchWord {...args} />
-);
+type Story = StoryObj<typeof SearchWord>;
 
-export const PlusWord = Template.bind({});
-PlusWord.args = {
-  word: 'あいうえお',
-  sx: {},
+export const PlusWord: Story = {
+  args: {
+    word: 'あいうえお',
+    sx: {},
+  },
 };
-
-export const MinusWord = Template.bind({});
-MinusWord.args = {
-  word: '-かきくけこ',
-  sx: {},
+export const MinusWord: Story = {
+  args: {
+    word: '-かきくけこ',
+    sx: {},
+  },
 };

--- a/src/components/atoms/TagBadge.stories.tsx
+++ b/src/components/atoms/TagBadge.stories.tsx
@@ -1,9 +1,8 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { TagBadge } from './TagBadge';
 
-const componentMeta: ComponentMeta<typeof TagBadge> = {
+const meta: Meta<typeof TagBadge> = {
   title: 'Atoms/TagBadge',
   component: TagBadge,
   argTypes: {
@@ -11,14 +10,13 @@ const componentMeta: ComponentMeta<typeof TagBadge> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof TagBadge> = (args) => (
-  <TagBadge {...args} />
-);
+type Story = StoryObj<typeof TagBadge>;
 
-export const Badge = Template.bind({});
-Badge.args = {
-  children: 'タグ',
-  sx: {},
+export const Badge: Story = {
+  args: {
+    children: 'タグ',
+    sx: {},
+  },
 };

--- a/src/components/molecules/AutocompleteForm.stories.tsx
+++ b/src/components/molecules/AutocompleteForm.stories.tsx
@@ -1,10 +1,9 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SearchType } from '../../lib/search-target';
 import { AutocompleteForm } from './AutocompleteForm';
 
-const componentMeta: ComponentMeta<typeof AutocompleteForm> = {
+const meta: Meta<typeof AutocompleteForm> = {
   title: 'Molecules/AutocompleteForm',
   component: AutocompleteForm,
   argTypes: {
@@ -14,32 +13,31 @@ const componentMeta: ComponentMeta<typeof AutocompleteForm> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof AutocompleteForm> = (args) => (
-  <AutocompleteForm {...args} />
-);
+type Story = StoryObj<typeof AutocompleteForm>;
 
-export const SearchByTag = Template.bind({});
-SearchByTag.args = {
-  target: { type: SearchType.TAG, category: '五十音' },
-  words: [],
-  autocompleteOptions: ['あいうえお', 'かきくけこ'],
-  sx: {},
+export const SearchByTag: Story = {
+  args: {
+    target: { type: SearchType.TAG, category: '五十音' },
+    words: [],
+    autocompleteOptions: ['あいうえお', 'かきくけこ'],
+    sx: {},
+  },
 };
-
-export const SearchByName = Template.bind({});
-SearchByName.args = {
-  target: { type: SearchType.NAME },
-  words: [],
-  autocompleteOptions: ['さしすせそ', 'たちつてと'],
-  sx: {},
+export const SearchByName: Story = {
+  args: {
+    target: { type: SearchType.NAME },
+    words: [],
+    autocompleteOptions: ['さしすせそ', 'たちつてと'],
+    sx: {},
+  },
 };
-
-export const InputtedWords = Template.bind({});
-InputtedWords.args = {
-  target: { type: SearchType.TAG, category: '五十音' },
-  words: ['あいうえお', 'なにぬねの', '-はひふへほ'],
-  autocompleteOptions: ['なにぬねの', 'はひふへほ', 'まみむめも'],
-  sx: {},
+export const InputtedWords: Story = {
+  args: {
+    target: { type: SearchType.TAG, category: '五十音' },
+    words: ['あいうえお', 'なにぬねの', '-はひふへほ'],
+    autocompleteOptions: ['なにぬねの', 'はひふへほ', 'まみむめも'],
+    sx: {},
+  },
 };

--- a/src/components/molecules/CharacterCard.stories.tsx
+++ b/src/components/molecules/CharacterCard.stories.tsx
@@ -1,9 +1,8 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { CharacterCard } from './CharacterCard';
 
-const componentMeta: ComponentMeta<typeof CharacterCard> = {
+const meta: Meta<typeof CharacterCard> = {
   title: 'Molecules/CharacterCard',
   component: CharacterCard,
   argTypes: {
@@ -12,39 +11,38 @@ const componentMeta: ComponentMeta<typeof CharacterCard> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof CharacterCard> = (args) => (
-  <CharacterCard {...args} />
-);
+type Story = StoryObj<typeof CharacterCard>;
 
-export const Card = Template.bind({});
-Card.args = {
-  name: 'なまえ',
-  tags: [
-    { category: 'あいうえお', label: 'タグ1' },
-    { category: 'かきくけこ', label: 'タグ2' },
-  ],
-  sx: {},
+export const Card: Story = {
+  args: {
+    name: 'なまえ',
+    tags: [
+      { category: 'あいうえお', label: 'タグ1' },
+      { category: 'かきくけこ', label: 'タグ2' },
+    ],
+    sx: {},
+  },
 };
-
-export const OverflowTags = Template.bind({});
-OverflowTags.args = {
-  name: 'なまえ',
-  tags: Array.from({ length: 32 }, (_, index) => ({
-    category: `カテゴリー${index + 1}`,
-    label: `タグ${index + 1}`,
-  })),
-  sx: {},
+export const OverflowTags: Story = {
+  args: {
+    name: 'なまえ',
+    tags: Array.from({ length: 32 }, (_, index) => ({
+      category: `カテゴリー${index + 1}`,
+      label: `タグ${index + 1}`,
+    })),
+    sx: {},
+  },
 };
-
-export const DuplicateTagLabels = Template.bind({});
-DuplicateTagLabels.args = {
-  name: 'なまえ',
-  tags: [
-    { category: 'あいうえお', label: 'タグ1' },
-    { category: 'かきくけこ', label: 'タグ2' },
-    { category: 'さしすせそ', label: 'タグ2' },
-  ],
-  sx: {},
+export const DuplicateTagLabels: Story = {
+  args: {
+    name: 'なまえ',
+    tags: [
+      { category: 'あいうえお', label: 'タグ1' },
+      { category: 'かきくけこ', label: 'タグ2' },
+      { category: 'さしすせそ', label: 'タグ2' },
+    ],
+    sx: {},
+  },
 };

--- a/src/components/molecules/SearchTypeAndWords.stories.tsx
+++ b/src/components/molecules/SearchTypeAndWords.stories.tsx
@@ -1,9 +1,8 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SearchTypeAndWords } from './SearchTypeAndWords';
 
-const componentMeta: ComponentMeta<typeof SearchTypeAndWords> = {
+const meta: Meta<typeof SearchTypeAndWords> = {
   title: 'Molecules/SearchTypeandWords',
   component: SearchTypeAndWords,
   argTypes: {
@@ -12,43 +11,42 @@ const componentMeta: ComponentMeta<typeof SearchTypeAndWords> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof SearchTypeAndWords> = (args) => (
-  <SearchTypeAndWords {...args} />
-);
+type Story = StoryObj<typeof SearchTypeAndWords>;
 
-export const SearchByTag = Template.bind({});
-SearchByTag.args = {
-  nameWords: [],
-  tagWords: ['ハル'],
-  sx: {},
+export const SearchByTag: Story = {
+  args: {
+    nameWords: [],
+    tagWords: ['ハル'],
+    sx: {},
+  },
 };
-
-export const SearchByName = Template.bind({});
-SearchByName.args = {
-  nameWords: ['ナツ'],
-  tagWords: [],
-  sx: {},
+export const SearchByName: Story = {
+  args: {
+    nameWords: ['ナツ'],
+    tagWords: [],
+    sx: {},
+  },
 };
-
-export const SearchByBoth = Template.bind({});
-SearchByBoth.args = {
-  nameWords: ['ナツ'],
-  tagWords: ['きせつ'],
-  sx: {},
+export const SearchByBoth: Story = {
+  args: {
+    nameWords: ['ナツ'],
+    tagWords: ['きせつ'],
+    sx: {},
+  },
 };
-
-export const MultipleWords = Template.bind({});
-MultipleWords.args = {
-  nameWords: [],
-  tagWords: ['アキ', 'フユ'],
-  sx: {},
+export const MultipleWords: Story = {
+  args: {
+    nameWords: [],
+    tagWords: ['アキ', 'フユ'],
+    sx: {},
+  },
 };
-
-export const MinusWord = Template.bind({});
-MinusWord.args = {
-  nameWords: ['-梅雨'],
-  tagWords: [],
-  sx: {},
+export const MinusWord: Story = {
+  args: {
+    nameWords: ['-梅雨'],
+    tagWords: [],
+    sx: {},
+  },
 };

--- a/src/components/molecules/ShowAllModelsSwitch.stories.tsx
+++ b/src/components/molecules/ShowAllModelsSwitch.stories.tsx
@@ -1,9 +1,8 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { ShowAllModelsSwitch } from './ShowAllModelsSwitch';
 
-const componentMeta: ComponentMeta<typeof ShowAllModelsSwitch> = {
+const meta: Meta<typeof ShowAllModelsSwitch> = {
   title: 'Molecules/ShowAllModelsSwitch',
   component: ShowAllModelsSwitch,
   argTypes: {
@@ -11,20 +10,19 @@ const componentMeta: ComponentMeta<typeof ShowAllModelsSwitch> = {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof ShowAllModelsSwitch> = (args) => (
-  <ShowAllModelsSwitch {...args} />
-);
+type Story = StoryObj<typeof ShowAllModelsSwitch>;
 
-export const Unchecked = Template.bind({});
-Unchecked.args = {
-  checked: false,
-  sx: {},
+export const Unchecked: Story = {
+  args: {
+    checked: false,
+    sx: {},
+  },
 };
-
-export const Checked = Template.bind({});
-Checked.args = {
-  checked: true,
-  sx: {},
+export const Checked: Story = {
+  args: {
+    checked: true,
+    sx: {},
+  },
 };

--- a/src/components/molecules/SortOrderSelector.stories.tsx
+++ b/src/components/molecules/SortOrderSelector.stories.tsx
@@ -8,9 +8,14 @@ const meta: Meta<typeof SortOrderSelector> = {
   component: SortOrderSelector,
   argTypes: {
     value: {
-      options: Object.keys(SortOrder).filter((key) => isNaN(Number(key))),
-      mapping: SortOrder,
-      control: 'radio',
+      control: {
+        type: 'select',
+        labels: Object.fromEntries(
+          Object.entries(SortOrder).filter(
+            ([, value]) => typeof value === 'string'
+          )
+        ),
+      },
     },
     sx: { control: 'object' },
   },

--- a/src/components/molecules/SortOrderSelector.stories.tsx
+++ b/src/components/molecules/SortOrderSelector.stories.tsx
@@ -1,10 +1,9 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SortOrder } from '../../lib/sort-characters';
 import { SortOrderSelector } from './SortOrderSelector';
 
-const componentMeta: ComponentMeta<typeof SortOrderSelector> = {
+const meta: Meta<typeof SortOrderSelector> = {
   title: 'Molecules/SortOrderSelector',
   component: SortOrderSelector,
   argTypes: {
@@ -16,15 +15,13 @@ const componentMeta: ComponentMeta<typeof SortOrderSelector> = {
     sx: { control: 'object' },
   },
 };
+export default meta;
 
-export default componentMeta;
+type Story = StoryObj<typeof SortOrderSelector>;
 
-const Template: ComponentStory<typeof SortOrderSelector> = (args) => (
-  <SortOrderSelector {...args} />
-);
-
-export const Selector = Template.bind({});
-Selector.args = {
-  value: SortOrder.ID,
-  sx: {},
+export const Selector: Story = {
+  args: {
+    value: SortOrder.ID,
+    sx: {},
+  },
 };

--- a/src/components/organisms/FullSearchForm.stories.tsx
+++ b/src/components/organisms/FullSearchForm.stories.tsx
@@ -1,22 +1,20 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { FullSearchForm } from './FullSearchForm';
 
-const componentMeta: ComponentMeta<typeof FullSearchForm> = {
+const meta: Meta<typeof FullSearchForm> = {
   title: 'Organisms/FullSearchForm',
   component: FullSearchForm,
   argTypes: {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof FullSearchForm> = (args) => (
-  <FullSearchForm {...args} />
-);
+type Story = StoryObj<typeof FullSearchForm>;
 
-export const Search = Template.bind({});
-Search.args = {
-  sx: {},
+export const Search: Story = {
+  args: {
+    sx: {},
+  },
 };

--- a/src/components/organisms/SearchConditionSummary.stories.tsx
+++ b/src/components/organisms/SearchConditionSummary.stories.tsx
@@ -1,22 +1,20 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SearchConditionSummary } from './SearchConditionSummary';
 
-const componentMeta: ComponentMeta<typeof SearchConditionSummary> = {
+const meta: Meta<typeof SearchConditionSummary> = {
   title: 'Organisms/SearchConditionSummary',
   component: SearchConditionSummary,
   argTypes: {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof SearchConditionSummary> = (args) => (
-  <SearchConditionSummary {...args} />
-);
+type Story = StoryObj<typeof SearchConditionSummary>;
 
-export const Condition = Template.bind({});
-Condition.args = {
-  sx: {},
+export const Condition: Story = {
+  args: {
+    sx: {},
+  },
 };

--- a/src/components/organisms/SearchResults.stories.tsx
+++ b/src/components/organisms/SearchResults.stories.tsx
@@ -1,22 +1,20 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react';
-import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import { SearchResults } from './SearchResults';
 
-const componentMeta: ComponentMeta<typeof SearchResults> = {
+const meta: Meta<typeof SearchResults> = {
   title: 'Organisms/SearchResult',
   component: SearchResults,
   argTypes: {
     sx: { control: 'object' },
   },
 };
-export default componentMeta;
+export default meta;
 
-const Template: ComponentStory<typeof SearchResults> = (args) => (
-  <SearchResults {...args} />
-);
+type Story = StoryObj<typeof SearchResults>;
 
-export const Results = Template.bind({});
-Results.args = {
-  sx: {},
+export const Results: Story = {
+  args: {
+    sx: {},
+  },
 };


### PR DESCRIPTION
Resolve #113 

- storybook7の書き方でstoryを書く
    - `ComponentMeta` から `Meta` に移行
    - `Template.bind` から`StoryObj` に移行
- `molecules/SortOrderSelector` が初期状態で無選択状態になるバグを修正
    - 多分enum周りのあれこれでargTypesとargsが衝突してたっぽい