### PR TITLE
Vercel Analyticsを導入する

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.2",
     "@next/font": "^13.1.3",
+    "@vercel/analytics": "^0.1.8",
     "next": "^13.0.0",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
+import { Analytics } from '@vercel/analytics/react';
 import React from 'react';
 
 import { FluxProvider } from '../flux/context';
@@ -29,6 +30,7 @@ const RootLayout = ({ children }: Props) => (
           <FluxProvider>{children}</FluxProvider>
         </ThemeProvider>
       </main>
+      <Analytics />
     </body>
   </html>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,6 +3485,11 @@
     "@typescript-eslint/types" "5.48.2"
     eslint-visitor-keys "^3.3.0"
 
+"@vercel/analytics@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-0.1.8.tgz#71f1f8c7bb98ac0c5c47eb3fb8ccbe8141b9fe47"
+  integrity sha512-PQrOI8BJ9qUiVJuQfnKiJd15eDjDJH9TBKsNeMrtelT4NAk7d9mBVz1CoZkvoFnHQ0OW7Xnqmr1F2nScfAnznQ==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
Resolve #122 

- `@vercel/analytics` の導入
- 全てのページで `VercelAnalytics` コンポーネントが追加されるようにする
    - 今はindexしかないけど将来的にページ追加したときのため