### PR TITLE
タグの種類ごとに表示を分ける

### DIFF
--- a/src/components/molecules/CategorizedTags.stories.tsx
+++ b/src/components/molecules/CategorizedTags.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { CategorizedTags } from './CategorizedTags';
+
+const meta: Meta<typeof CategorizedTags> = {
+  title: 'Molecules/CategorizedTags',
+  component: CategorizedTags,
+  argTypes: {
+    label: { control: 'text' },
+    tags: { control: 'object' },
+    sx: { control: 'object' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CategorizedTags>;
+
+export const Categorized: Story = {
+  args: {
+    label: 'あいう',
+    tags: ['タグ1', 'タグ2', 'タグ3'],
+    sx: {},
+  },
+};

--- a/src/components/molecules/CategorizedTags.tsx
+++ b/src/components/molecules/CategorizedTags.tsx
@@ -1,0 +1,58 @@
+import Stack from '@mui/material/Stack';
+import { SxProps, Theme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { TagBadge } from '../atoms/TagBadge';
+
+interface Props {
+  /**
+   * タグの種類
+   */
+  label: string;
+  /**
+   * 表示するタグ一覧
+   */
+  tags: string[];
+  /**
+   * タグクリック時のハンドラ
+   * @param tagLabel - タグ
+   */
+  onClickTag: (tagLabel: string) => void;
+  /**
+   * テーマ関係のスタイル指定
+   */
+  sx?: SxProps<Theme>;
+}
+
+export const CategorizedTags: React.FC<Props> = ({
+  label,
+  tags,
+  onClickTag,
+  sx,
+}) => {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" sx={sx}>
+      <Typography flexShrink={0}>{label}</Typography>
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{
+          display: 'inline-block',
+          whiteSpace: 'nowrap',
+          overflowX: 'scroll',
+        }}
+      >
+        {tags.length > 0 ? (
+          tags.map((tag) => (
+            <TagBadge key={tag} onClick={onClickTag}>
+              {tag}
+            </TagBadge>
+          ))
+        ) : (
+          <Typography>なし</Typography>
+        )}
+      </Stack>
+    </Stack>
+  );
+};

--- a/src/components/molecules/CategorizedTags.tsx
+++ b/src/components/molecules/CategorizedTags.tsx
@@ -32,7 +32,13 @@ export const CategorizedTags: React.FC<Props> = ({
   sx,
 }) => {
   return (
-    <Stack direction="row" spacing={1} alignItems="center" sx={sx}>
+    <Stack
+      direction="row"
+      spacing={1}
+      alignItems="center"
+      minHeight="2rem"
+      sx={sx}
+    >
       <Typography flexShrink={0}>{label}</Typography>
       <Stack
         direction="row"

--- a/src/components/molecules/ShipCard.stories.tsx
+++ b/src/components/molecules/ShipCard.stories.tsx
@@ -6,8 +6,7 @@ const meta: Meta<typeof ShipCard> = {
   title: 'Molecules/ShipCard',
   component: ShipCard,
   argTypes: {
-    name: { control: 'text' },
-    tags: { control: 'object' },
+    ship: { control: 'object' },
     sx: { control: 'object' },
   },
 };
@@ -17,16 +16,36 @@ type Story = StoryObj<typeof ShipCard>;
 
 export const Card: Story = {
   args: {
-    name: 'なまえ',
-    tags: ['タグ1', 'タグ2'],
+    ship: {
+      id: 1,
+      name: 'なまえ',
+      kana: 'なまえ',
+      category: '補助艦艇',
+      type: '補給艦',
+      speed: '高速',
+      range: '短射程',
+      equipments: ['タグ1'],
+      abilities: ['タグ2'],
+      showDefault: true,
+    },
     sx: {},
   },
 };
 
 export const OverflowTags: Story = {
   args: {
-    name: 'なまえ',
-    tags: Array.from({ length: 32 }, (_, index) => `タグ${index + 1}`),
+    ship: {
+      id: 1,
+      name: 'なまえ',
+      kana: 'なまえ',
+      category: '航空母艦',
+      type: '正規空母',
+      speed: '高速',
+      range: '短射程',
+      equipments: Array.from({ length: 16 }, (_, index) => `装備${index + 1}`),
+      abilities: Array.from({ length: 16 }, (_, index) => `特性${index + 1}`),
+      showDefault: true,
+    },
     sx: {},
   },
 };

--- a/src/components/molecules/ShipCard.tsx
+++ b/src/components/molecules/ShipCard.tsx
@@ -1,13 +1,12 @@
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Divider from '@mui/material/Divider';
-import Stack from '@mui/material/Stack';
 import { SxProps, Theme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import { Ship } from '../../lib/ship';
-import { TagBadge } from '../atoms/TagBadge';
+import { CategorizedTags } from './CategorizedTags';
 
 interface Props {
   /**
@@ -41,64 +40,36 @@ export const ShipCard: React.FC<Props> = ({ ship, onClickTag, sx }) => {
           {name}
         </Typography>
         <Divider sx={{ mt: 1 }} />
-        <Stack direction="row" spacing={1} mt={1} alignItems="center">
-          <Typography>艦種</Typography>
-          <TagBadge onClick={onClickTag}>{category}</TagBadge>
-          <TagBadge onClick={onClickTag}>{type}</TagBadge>
-        </Stack>
-        <Stack direction="row" spacing={1} mt={1} alignItems="center">
-          <Typography>速力</Typography>
-          <TagBadge onClick={onClickTag}>{speed}</TagBadge>
-        </Stack>
-        <Stack direction="row" spacing={1} mt={1} alignItems="center">
-          <Typography>射程</Typography>
-          <TagBadge onClick={onClickTag}>{range}</TagBadge>
-        </Stack>
-        {/* スクロールバーがタグと被らないように下部余白を確保する */}
-        <Stack direction="row" spacing={1} mt={1} alignItems="center">
-          <Typography flexShrink={0}>装備</Typography>
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{
-              display: 'inline-block',
-              whiteSpace: 'nowrap',
-              overflowX: 'scroll',
-            }}
-          >
-            {equipments.length > 0 ? (
-              equipments.map((tag) => (
-                <TagBadge key={tag} onClick={onClickTag}>
-                  {tag}
-                </TagBadge>
-              ))
-            ) : (
-              <Typography>なし</Typography>
-            )}
-          </Stack>
-        </Stack>
-        <Stack direction="row" spacing={1} mt={1} alignItems="center">
-          <Typography flexShrink={0}>特性</Typography>
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{
-              display: 'inline-block',
-              whiteSpace: 'nowrap',
-              overflowX: 'scroll',
-            }}
-          >
-            {abilities.length > 0 ? (
-              abilities.map((tag) => (
-                <TagBadge key={tag} onClick={onClickTag}>
-                  {tag}
-                </TagBadge>
-              ))
-            ) : (
-              <Typography>なし</Typography>
-            )}
-          </Stack>
-        </Stack>
+        <CategorizedTags
+          label="艦種"
+          tags={[category, type]}
+          onClickTag={onClickTag}
+          sx={{ mt: 1 }}
+        />
+        <CategorizedTags
+          label="速力"
+          tags={[speed]}
+          onClickTag={onClickTag}
+          sx={{ mt: 1 }}
+        />
+        <CategorizedTags
+          label="射程"
+          tags={[range]}
+          onClickTag={onClickTag}
+          sx={{ mt: 1 }}
+        />
+        <CategorizedTags
+          label="装備"
+          tags={equipments}
+          onClickTag={onClickTag}
+          sx={{ mt: 1 }}
+        />
+        <CategorizedTags
+          label="特性"
+          tags={abilities}
+          onClickTag={onClickTag}
+          sx={{ mt: 1 }}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/molecules/ShipCard.tsx
+++ b/src/components/molecules/ShipCard.tsx
@@ -6,17 +6,14 @@ import Stack from '@mui/material/Stack';
 import { SxProps, Theme } from '@mui/material/styles';
 import React from 'react';
 
+import { Ship } from '../../lib/ship';
 import { TagBadge } from '../atoms/TagBadge';
 
 interface Props {
   /**
-   * キャラ名
+   * 艦船データ
    */
-  name: string;
-  /**
-   * タグ一覧
-   */
-  tags: string[];
+  ship: Ship;
   /**
    * タグクリック時のハンドラ
    * @param tagLabel - タグ
@@ -28,11 +25,13 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const ShipCard: React.FC<Props> = ({ name, tags, onClickTag, sx }) => {
+export const ShipCard: React.FC<Props> = ({ ship, onClickTag, sx }) => {
+  const { category, type, speed, range, equipments, abilities } = ship;
+  const tags = [category, type, speed, range, ...equipments, ...abilities];
   const uniqueTags = Array.from(new Set(tags));
   return (
     <Card elevation={2} sx={sx}>
-      <CardHeader title={name} />
+      <CardHeader title={ship.name} />
       <CardContent>
         {/* スクロールバーがタグと被らないように下部余白を確保する */}
         <Box pb={1} sx={{ overflowX: 'scroll' }}>

--- a/src/components/molecules/ShipCard.tsx
+++ b/src/components/molecules/ShipCard.tsx
@@ -1,9 +1,9 @@
-import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import CardHeader from '@mui/material/CardHeader';
+import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import { SxProps, Theme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import { Ship } from '../../lib/ship';
@@ -26,27 +26,79 @@ interface Props {
 }
 
 export const ShipCard: React.FC<Props> = ({ ship, onClickTag, sx }) => {
-  const { category, type, speed, range, equipments, abilities } = ship;
-  const tags = [category, type, speed, range, ...equipments, ...abilities];
-  const uniqueTags = Array.from(new Set(tags));
+  const { name, category, type, speed, range, equipments, abilities } = ship;
   return (
     <Card elevation={2} sx={sx}>
-      <CardHeader title={ship.name} />
       <CardContent>
+        <Typography
+          variant="h5"
+          component="span"
+          flex={1}
+          textOverflow="ellipsis"
+          overflow="hidden"
+          whiteSpace="nowrap"
+        >
+          {name}
+        </Typography>
+        <Divider sx={{ mt: 1 }} />
+        <Stack direction="row" spacing={1} mt={1} alignItems="center">
+          <Typography>艦種</Typography>
+          <TagBadge onClick={onClickTag}>{category}</TagBadge>
+          <TagBadge onClick={onClickTag}>{type}</TagBadge>
+        </Stack>
+        <Stack direction="row" spacing={1} mt={1} alignItems="center">
+          <Typography>速力</Typography>
+          <TagBadge onClick={onClickTag}>{speed}</TagBadge>
+        </Stack>
+        <Stack direction="row" spacing={1} mt={1} alignItems="center">
+          <Typography>射程</Typography>
+          <TagBadge onClick={onClickTag}>{range}</TagBadge>
+        </Stack>
         {/* スクロールバーがタグと被らないように下部余白を確保する */}
-        <Box pb={1} sx={{ overflowX: 'scroll' }}>
+        <Stack direction="row" spacing={1} mt={1} alignItems="center">
+          <Typography flexShrink={0}>装備</Typography>
           <Stack
             direction="row"
             spacing={1}
-            sx={{ display: 'inline-block', whiteSpace: 'nowrap' }}
+            sx={{
+              display: 'inline-block',
+              whiteSpace: 'nowrap',
+              overflowX: 'scroll',
+            }}
           >
-            {uniqueTags.map((tag) => (
-              <TagBadge key={tag} onClick={onClickTag}>
-                {tag}
-              </TagBadge>
-            ))}
+            {equipments.length > 0 ? (
+              equipments.map((tag) => (
+                <TagBadge key={tag} onClick={onClickTag}>
+                  {tag}
+                </TagBadge>
+              ))
+            ) : (
+              <Typography>なし</Typography>
+            )}
           </Stack>
-        </Box>
+        </Stack>
+        <Stack direction="row" spacing={1} mt={1} alignItems="center">
+          <Typography flexShrink={0}>特性</Typography>
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{
+              display: 'inline-block',
+              whiteSpace: 'nowrap',
+              overflowX: 'scroll',
+            }}
+          >
+            {abilities.length > 0 ? (
+              abilities.map((tag) => (
+                <TagBadge key={tag} onClick={onClickTag}>
+                  {tag}
+                </TagBadge>
+              ))
+            ) : (
+              <Typography>なし</Typography>
+            )}
+          </Stack>
+        </Stack>
       </CardContent>
     </Card>
   );

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -36,23 +36,11 @@ export const SearchResults: React.FC<Props> = ({ sx }) => {
   return (
     <InfiniteScroller loadMore={loadMore} hasMore={hasMore}>
       <Grid container spacing={2} sx={sx}>
-        {shownShips.map(
-          ({ name, category, type, speed, range, equipments, abilities }) => {
-            const tags = [
-              category,
-              type,
-              speed,
-              range,
-              ...equipments,
-              ...abilities,
-            ];
-            return (
-              <Grid item key={name} xs={12} sm={6} md={4}>
-                <ShipCard name={name} tags={tags} onClickTag={onClickTag} />
-              </Grid>
-            );
-          }
-        )}
+        {shownShips.map((ship) => (
+          <Grid item key={ship.name} xs={12} sm={6} md={4}>
+            <ShipCard ship={ship} onClickTag={onClickTag} />
+          </Grid>
+        ))}
       </Grid>
     </InfiniteScroller>
   );


### PR DESCRIPTION
- 艦船表示ではタグの種類ごとに一覧を表示する (Resolve #108)
    - 装備や特性のタグがない場合は「なし」と表示して、バグと思われないようにする
- ShipCardがShipそのものを受け取るようにする