### PR TITLE
同名タグをクリックしたときにカテゴリーで区別できるようにする

### DIFF
--- a/src/components/atoms/TagBadge.stories.tsx
+++ b/src/components/atoms/TagBadge.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof TagBadge> = {
   title: 'Atoms/TagBadge',
   component: TagBadge,
   argTypes: {
-    children: { control: 'text' },
+    tag: { control: 'text' },
     sx: { control: 'object' },
   },
 };
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof TagBadge>;
 
 export const Badge: Story = {
   args: {
-    children: 'タグ',
+    tag: 'タグ',
     sx: {},
   },
 };

--- a/src/components/atoms/TagBadge.stories.tsx
+++ b/src/components/atoms/TagBadge.stories.tsx
@@ -1,11 +1,13 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import { AllTagCategories } from '../../lib/tag-category';
 import { TagBadge } from './TagBadge';
 
 const meta: Meta<typeof TagBadge> = {
   title: 'Atoms/TagBadge',
   component: TagBadge,
   argTypes: {
+    category: { control: 'select', options: AllTagCategories },
     tag: { control: 'text' },
     sx: { control: 'object' },
   },
@@ -16,6 +18,7 @@ type Story = StoryObj<typeof TagBadge>;
 
 export const Badge: Story = {
   args: {
+    category: 'categories',
     tag: 'タグ',
     sx: {},
   },

--- a/src/components/atoms/TagBadge.tsx
+++ b/src/components/atoms/TagBadge.tsx
@@ -15,23 +15,24 @@ interface Props {
   tag: string;
   /**
    * クリック時の挙動
+   * @param category - クリックされたタグの種類
    * @param tag - クリックされたタグ
    */
-  onClick: (tag: string) => void;
+  onClick: (category: TagCategory, tag: string) => void;
   /**
    * テーマ関係のスタイル指定
    */
   sx?: SxProps<Theme>;
 }
 
-export const TagBadge: React.FC<Props> = ({ tag, onClick, sx }) => {
+export const TagBadge: React.FC<Props> = ({ category, tag, onClick, sx }) => {
   const onClickButton = React.useCallback(
     (e: React.MouseEvent) => {
       // organisms/ShipCard のアコーディオンが反応しないよう伝播を止める
       e.stopPropagation();
-      onClick(tag);
+      onClick(category, tag);
     },
-    [onClick, tag]
+    [onClick, category, tag]
   );
   return (
     <Button

--- a/src/components/atoms/TagBadge.tsx
+++ b/src/components/atoms/TagBadge.tsx
@@ -2,7 +2,13 @@ import Button from '@mui/material/Button';
 import { SxProps, Theme } from '@mui/material/styles';
 import React from 'react';
 
+import { TagCategory } from '../../lib/tag-category';
+
 interface Props {
+  /**
+   * タグの種類
+   */
+  category: TagCategory;
   /**
    * タグ
    */

--- a/src/components/atoms/TagBadge.tsx
+++ b/src/components/atoms/TagBadge.tsx
@@ -6,7 +6,7 @@ interface Props {
   /**
    * タグ
    */
-  children: string;
+  tag: string;
   /**
    * クリック時の挙動
    * @param tag - クリックされたタグ
@@ -18,18 +18,14 @@ interface Props {
   sx?: SxProps<Theme>;
 }
 
-export const TagBadge: React.FC<Props> = ({
-  children: children,
-  onClick,
-  sx,
-}) => {
+export const TagBadge: React.FC<Props> = ({ tag, onClick, sx }) => {
   const onClickButton = React.useCallback(
     (e: React.MouseEvent) => {
       // organisms/ShipCard のアコーディオンが反応しないよう伝播を止める
       e.stopPropagation();
-      onClick(children);
+      onClick(tag);
     },
-    [onClick, children]
+    [onClick, tag]
   );
   return (
     <Button
@@ -38,7 +34,7 @@ export const TagBadge: React.FC<Props> = ({
       onClick={onClickButton}
       sx={{ textTransform: 'none', ...sx }}
     >
-      {children}
+      {tag}
     </Button>
   );
 };

--- a/src/components/molecules/CategorizedTags.stories.tsx
+++ b/src/components/molecules/CategorizedTags.stories.tsx
@@ -1,12 +1,13 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import { AllTagCategories } from '../../lib/tag-category';
 import { CategorizedTags } from './CategorizedTags';
 
 const meta: Meta<typeof CategorizedTags> = {
   title: 'Molecules/CategorizedTags',
   component: CategorizedTags,
   argTypes: {
-    label: { control: 'text' },
+    category: { control: 'select', options: AllTagCategories },
     tags: { control: 'object' },
     sx: { control: 'object' },
   },
@@ -17,7 +18,7 @@ type Story = StoryObj<typeof CategorizedTags>;
 
 export const Categorized: Story = {
   args: {
-    label: 'あいう',
+    category: 'equipments',
     tags: ['タグ1', 'タグ2', 'タグ3'],
     sx: {},
   },

--- a/src/components/molecules/CategorizedTags.tsx
+++ b/src/components/molecules/CategorizedTags.tsx
@@ -51,9 +51,7 @@ export const CategorizedTags: React.FC<Props> = ({
       >
         {tags.length > 0 ? (
           tags.map((tag) => (
-            <TagBadge key={tag} onClick={onClickTag}>
-              {tag}
-            </TagBadge>
+            <TagBadge key={tag} tag={tag} onClick={onClickTag} />
           ))
         ) : (
           <Typography>なし</Typography>

--- a/src/components/molecules/CategorizedTags.tsx
+++ b/src/components/molecules/CategorizedTags.tsx
@@ -18,9 +18,10 @@ interface Props {
   tags: string[];
   /**
    * タグクリック時のハンドラ
-   * @param tagLabel - タグ
+   * @param category - タグの種類
+   * @param tag - タグ
    */
-  onClickTag: (tagLabel: string) => void;
+  onClickTag: (category: TagCategory, tag: string) => void;
   /**
    * テーマ関係のスタイル指定
    */

--- a/src/components/molecules/CategorizedTags.tsx
+++ b/src/components/molecules/CategorizedTags.tsx
@@ -3,13 +3,15 @@ import { SxProps, Theme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 
+import { AllSearchTargetLabels } from '../../lib/search-target';
+import { TagCategory } from '../../lib/tag-category';
 import { TagBadge } from '../atoms/TagBadge';
 
 interface Props {
   /**
    * タグの種類
    */
-  label: string;
+  category: TagCategory;
   /**
    * 表示するタグ一覧
    */
@@ -26,11 +28,12 @@ interface Props {
 }
 
 export const CategorizedTags: React.FC<Props> = ({
-  label,
+  category,
   tags,
   onClickTag,
   sx,
 }) => {
+  const label = AllSearchTargetLabels[category];
   return (
     <Stack
       direction="row"
@@ -51,7 +54,12 @@ export const CategorizedTags: React.FC<Props> = ({
       >
         {tags.length > 0 ? (
           tags.map((tag) => (
-            <TagBadge key={tag} tag={tag} onClick={onClickTag} />
+            <TagBadge
+              key={tag}
+              category={category}
+              tag={tag}
+              onClick={onClickTag}
+            />
           ))
         ) : (
           <Typography>なし</Typography>

--- a/src/components/molecules/ShipCard.tsx
+++ b/src/components/molecules/ShipCard.tsx
@@ -38,8 +38,8 @@ export const ShipCard: React.FC<Props> = ({ ship, onClickTag, sx }) => {
             {name}
           </Typography>
           <Stack direction="row" spacing={1}>
-            <TagBadge onClick={onClickTag}>{category}</TagBadge>
-            <TagBadge onClick={onClickTag}>{type}</TagBadge>
+            <TagBadge onClick={onClickTag} tag={category} />
+            <TagBadge onClick={onClickTag} tag={type} />
           </Stack>
         </Stack>
       </AccordionSummary>

--- a/src/components/molecules/ShipCard.tsx
+++ b/src/components/molecules/ShipCard.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import { Ship } from '../../lib/ship';
+import { TagCategory } from '../../lib/tag-category';
 import { TagBadge } from '../atoms/TagBadge';
 import { CategorizedTags } from './CategorizedTags';
 
@@ -18,9 +19,10 @@ interface Props {
   ship: Ship;
   /**
    * タグクリック時のハンドラ
-   * @param tagLabel - タグ
+   * @param category - タグの種類
+   * @param tag - タグ
    */
-  onClickTag: (tagLabel: string) => void;
+  onClickTag: (category: TagCategory, tag: string) => void;
   /**
    * テーマ関係のスタイル指定
    */

--- a/src/components/molecules/ShipCard.tsx
+++ b/src/components/molecules/ShipCard.tsx
@@ -38,8 +38,12 @@ export const ShipCard: React.FC<Props> = ({ ship, onClickTag, sx }) => {
             {name}
           </Typography>
           <Stack direction="row" spacing={1}>
-            <TagBadge onClick={onClickTag} tag={category} />
-            <TagBadge onClick={onClickTag} tag={type} />
+            <TagBadge
+              category="categories"
+              tag={category}
+              onClick={onClickTag}
+            />
+            <TagBadge category="types" tag={type} onClick={onClickTag} />
           </Stack>
         </Stack>
       </AccordionSummary>
@@ -47,25 +51,25 @@ export const ShipCard: React.FC<Props> = ({ ship, onClickTag, sx }) => {
         sx={{ borderTop: '1px solid', borderColor: theme.palette.divider }}
       >
         <CategorizedTags
-          label="速力"
+          category="speeds"
           tags={[speed]}
           onClickTag={onClickTag}
           sx={{ mt: 1 }}
         />
         <CategorizedTags
-          label="射程"
+          category="ranges"
           tags={[range]}
           onClickTag={onClickTag}
           sx={{ mt: 1 }}
         />
         <CategorizedTags
-          label="装備"
+          category="equipments"
           tags={equipments}
           onClickTag={onClickTag}
           sx={{ mt: 1 }}
         />
         <CategorizedTags
-          label="特性"
+          category="abilities"
           tags={abilities}
           onClickTag={onClickTag}
           sx={{ mt: 1 }}

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import InfiniteScroller from 'react-infinite-scroller';
 
 import { FluxContext } from '../../flux/context';
+import { TagCategory } from '../../lib/tag-category';
 import { ShipCard } from '../molecules/ShipCard';
 
 interface Props {
@@ -17,8 +18,8 @@ export const SearchResults: React.FC<Props> = ({ sx }) => {
   const { state, dispatch } = React.useContext(FluxContext);
   const { results: ships, page } = state.search;
   const onClickTag = React.useCallback(
-    (label: string) => {
-      dispatch({ type: 'click-tag', label });
+    (category: TagCategory, tag: string) => {
+      dispatch({ type: 'click-tag', category, tag });
     },
     [dispatch]
   );

--- a/src/flux/action.ts
+++ b/src/flux/action.ts
@@ -1,6 +1,7 @@
 import { SearchTarget } from '../lib/search-target';
 import { Ship } from '../lib/ship';
 import { SortOrder } from '../lib/sort-ships';
+import { TagCategory } from '../lib/tag-category';
 
 interface LoadShipsData {
   type: 'load-ships-data';
@@ -25,7 +26,8 @@ interface ChangeSortOrderAction {
 
 interface ClickTag {
   type: 'click-tag';
-  label: string;
+  category: TagCategory;
+  tag: string;
 }
 
 interface ShowNextPage {

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -2,6 +2,7 @@ import { generateAutocompleteOptions } from '../lib/autocomplete';
 import { filterShips } from '../lib/filter-ships';
 import { Ship } from '../lib/ship';
 import { SortOrder, sortShips } from '../lib/sort-ships';
+import { TagCategory } from '../lib/tag-category';
 import {
   onChangeSearchWords,
   onChangeShowAll,
@@ -192,19 +193,13 @@ describe('onChangeSortOrder', () => {
 
 describe('onClickTag', () => {
   let nextState: State;
-  const label = 'label';
+  const category: TagCategory = 'types';
+  const tag = 'tag';
 
   const currentState: State = {
     ...baseState,
     search: {
       ...baseState.search,
-      info: {
-        ...baseState.search.info,
-        autocompleteOptions: {
-          ...baseState.search.info.autocompleteOptions,
-          types: [label],
-        },
-      },
       words: {
         ...baseState.search.words,
         categories: ['abc'],
@@ -215,14 +210,11 @@ describe('onClickTag', () => {
   };
 
   beforeEach(() => {
-    nextState = onClickTag(currentState, label);
+    nextState = onClickTag(currentState, category, tag);
   });
 
   it('既存の検索ワードにクリックしたタグが追加されている', () => {
-    expect(nextState.search.words).toEqual({
-      ...currentState.search.words,
-      types: [label],
-    });
+    expect(nextState.search.words[category]).toEqual([tag]);
   });
 
   it('ページがリセットされている', () => {

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -1,8 +1,9 @@
 import { generateAutocompleteOptions } from '../lib/autocomplete';
 import { filterShips } from '../lib/filter-ships';
-import { AllSearchTargets, SearchTarget } from '../lib/search-target';
+import { SearchTarget } from '../lib/search-target';
 import { Ship } from '../lib/ship';
 import { SortOrder, sortShips } from '../lib/sort-ships';
+import { TagCategory } from '../lib/tag-category';
 import { State } from './state';
 
 export const onLoadShipsData = (state: State, ships: Ship[]): State => {
@@ -87,20 +88,16 @@ export const onChangeSortOrder = (
   };
 };
 
-export const onClickTag = (state: State, label: string): State => {
+export const onClickTag = (
+  state: State,
+  category: TagCategory,
+  tag: string
+): State => {
   const { ships, search } = state;
   const { words, showAll } = search;
-  const { autocompleteOptions } = search.info;
-  const tagCategories = AllSearchTargets.filter((target) =>
-    autocompleteOptions[target].includes(label)
-  );
   const newWords = {
     ...words,
-    ...Object.fromEntries(
-      tagCategories.map((target) => {
-        return [target, [...words[target], label]];
-      })
-    ),
+    [category]: [...words[category], tag],
   };
   const results = filterShips(ships, newWords, showAll);
   return {

--- a/src/flux/reducer.ts
+++ b/src/flux/reducer.ts
@@ -22,7 +22,7 @@ export const reducer: Reducer<State, Action> = (state, action) => {
     case 'change-sort-order':
       return onChangeSortOrder(state, action.sortOrder);
     case 'click-tag':
-      return onClickTag(state, action.label);
+      return onClickTag(state, action.category, action.tag);
     case 'show-next-page':
       return onShowNextPage(state);
     default:

--- a/src/lib/search-target.ts
+++ b/src/lib/search-target.ts
@@ -1,12 +1,6 @@
-export const AllSearchTargets = [
-  'categories',
-  'types',
-  'equipments',
-  'abilities',
-  'speeds',
-  'ranges',
-  'names',
-] as const;
+import { AllTagCategories } from './tag-category';
+
+export const AllSearchTargets = [...AllTagCategories, 'names'] as const;
 export type SearchTarget = typeof AllSearchTargets[number];
 
 export const AllSearchTargetLabels = {

--- a/src/lib/tag-category.ts
+++ b/src/lib/tag-category.ts
@@ -1,0 +1,9 @@
+export const AllTagCategories = [
+  'categories',
+  'types',
+  'equipments',
+  'abilities',
+  'speeds',
+  'ranges',
+] as const;
+export type TagCategory = typeof AllTagCategories[number];


### PR DESCRIPTION
- タグカテゴリーを用意して、検索対象はそこに名前を足す実装にする
- タグクリック時にカテゴリーで同名タグを区別する (Resolve #131)