### PR TITLE
補完候補の表示でReact warningが出ないようにする

### DIFF
--- a/src/components/molecules/AutocompleteForm.tsx
+++ b/src/components/molecules/AutocompleteForm.tsx
@@ -90,6 +90,13 @@ export const AutocompleteForm: React.FC<Props> = ({
           }}
         />
       )}
+      renderOption={(props, option) => {
+        return (
+          <li {...props} key={option}>
+            {option}
+          </li>
+        );
+      }}
       renderTags={(values: string[], getTagProps) =>
         values.map((value, index) => {
           const color = value.startsWith('-') ? 'error' : 'default';

--- a/src/components/molecules/AutocompleteForm.tsx
+++ b/src/components/molecules/AutocompleteForm.tsx
@@ -102,10 +102,10 @@ export const AutocompleteForm: React.FC<Props> = ({
           const color = value.startsWith('-') ? 'error' : 'default';
           return (
             <Chip
-              key={value}
               label={value}
               color={color}
               {...getTagProps({ index })}
+              key={value}
               sx={{ fontSize: theme.typography.h6 }}
             />
           );

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -29,8 +29,9 @@ export const SearchResults: React.FC<Props> = ({ sx }) => {
       type: 'show-next-page',
     });
   }, [dispatch]);
-  // 追加は24個ずつ
-  const shownShips = ships.slice(0, page * 24);
+  // 追加は12個ずつ
+  // PCやタブレットだとファーストビューで12+α見えるため、初回だけ2ページ分表示する
+  const shownShips = ships.slice(0, (page + 1) * 12);
   const hasMore = shownShips.length < ships.length;
 
   return (

--- a/src/components/organisms/SearchResults.tsx
+++ b/src/components/organisms/SearchResults.tsx
@@ -29,9 +29,8 @@ export const SearchResults: React.FC<Props> = ({ sx }) => {
       type: 'show-next-page',
     });
   }, [dispatch]);
-  // 追加は12個ずつ
-  // PCやタブレットだとファーストビューで12+α見えるため、初回だけ2ページ分表示する
-  const shownShips = ships.slice(0, (page + 1) * 12);
+  // 追加は24個ずつ
+  const shownShips = ships.slice(0, page * 24);
   const hasMore = shownShips.length < ships.length;
 
   return (


### PR DESCRIPTION
- 補完候補の `key` をspreadで指定されないようにしてwarningを回避する (Resolve #133)
- (おまけ)艦船カードを24個ずつ増やそうとしたけど重くて断念した