### PR TITLE
タグをサブカテゴリごとにグルーピングする

### DIFF
--- a/src/components/molecules/TagSelector.stories.tsx
+++ b/src/components/molecules/TagSelector.stories.tsx
@@ -20,7 +20,10 @@ type Story = StoryObj<typeof TagSelector>;
 export const Selector: Story = {
   args: {
     category: 'categories',
-    tags: ['駆逐艦', '軽巡級', '重巡級'],
+    tags: ['駆逐艦', '軽巡級', '重巡級'].map((label) => ({
+      label,
+      category: 'categories',
+    })),
     selectedTags: [],
   },
 };
@@ -28,7 +31,10 @@ export const Selector: Story = {
 export const Selected: Story = {
   args: {
     category: 'abilities',
-    tags: ['特性A', '特性B', '特性C'],
+    tags: ['特性A', '特性B', '特性C'].map((label) => ({
+      label,
+      category: 'abilities',
+    })),
     selectedTags: ['特性B', '特性C'],
   },
 };
@@ -36,7 +42,10 @@ export const Selected: Story = {
 export const MinusChecked: Story = {
   args: {
     category: 'equipments',
-    tags: ['装備A', '装備B', '装備C'],
+    tags: ['装備A', '装備B', '装備C'].map((label) => ({
+      label,
+      category: 'equipments',
+    })),
     selectedTags: ['-装備A', '装備B'],
   },
 };
@@ -44,7 +53,23 @@ export const MinusChecked: Story = {
 export const TooManyTags: Story = {
   args: {
     category: 'equipments',
-    tags: Array.from({ length: 16 }, (_, index) => `装備${index + 1}`),
+    tags: Array.from({ length: 16 }, (_, index) => ({
+      label: `装備${index + 1}`,
+      category: 'equipments',
+    })),
     selectedTags: Array.from({ length: 8 }, (_, index) => `装備${index + 1}`),
+  },
+};
+
+export const SubCategorized: Story = {
+  args: {
+    category: 'equipments',
+    tags: [
+      { label: '装備A', category: 'equipments', subCategory: 'サブカテゴリA' },
+      { label: '装備B', category: 'equipments', subCategory: 'サブカテゴリA' },
+      { label: '装備C', category: 'equipments', subCategory: 'サブカテゴリB' },
+      { label: '装備D', category: 'equipments', subCategory: 'サブカテゴリB' },
+    ],
+    selectedTags: ['装備A', '装備C'],
   },
 };

--- a/src/components/molecules/TagSelector.tsx
+++ b/src/components/molecules/TagSelector.tsx
@@ -110,7 +110,7 @@ export const TagSelector: React.FC<Props> = ({
           direction="column"
           divider={<Divider flexItem />}
           spacing={1}
-          sx={{ mt: 1 }}
+          mt={1}
         >
           {Array.from(subCategorizedTagMap.keys()).map((subCategory) => {
             const subCategorizedTags =
@@ -130,10 +130,10 @@ export const TagSelector: React.FC<Props> = ({
             });
 
             return (
-              <Stack key={subCategory} direction="column" spacing={1}>
+              <React.Fragment key={subCategory}>
                 {subCategory ? <Typography>{subCategory}</Typography> : null}
                 <FormGroup row>{checkboxes}</FormGroup>
-              </Stack>
+              </React.Fragment>
             );
           })}
         </Stack>

--- a/src/components/organisms/FullSearchForm.tsx
+++ b/src/components/organisms/FullSearchForm.tsx
@@ -21,6 +21,7 @@ type Props = {
 
 export const FullSearchForm: React.FC<Props> = ({ sx }) => {
   const { state, dispatch } = React.useContext(FluxContext);
+  const { tags } = state;
   const { info, words } = state.search;
   const { autocompleteOptions } = info;
   const onChangeCurried = React.useCallback(
@@ -40,11 +41,12 @@ export const FullSearchForm: React.FC<Props> = ({ sx }) => {
       <AccordionDetails>
         {AllTagCategories.map((category) => {
           const onChange = onChangeCurried(category);
+          const categoryTags = tags.filter((tag) => tag.category === category);
           return (
             <TagSelector
               key={category}
               category={category}
-              tags={autocompleteOptions[category]}
+              tags={categoryTags}
               selectedTags={words[category]}
               onChange={onChange}
             />

--- a/src/components/organisms/FullSearchForm.tsx
+++ b/src/components/organisms/FullSearchForm.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import { FluxContext } from '../../flux/context';
 import { SearchTarget } from '../../lib/search-target';
+import { Tag } from '../../lib/tag';
 import { AllTagCategories } from '../../lib/tag-category';
 import { AutocompleteForm } from '../molecules/AutocompleteForm';
 import { TagSelector } from '../molecules/TagSelector';
@@ -29,6 +30,14 @@ export const FullSearchForm: React.FC<Props> = ({ sx }) => {
     },
     [dispatch]
   );
+  const categoryToTags = React.useMemo(() => {
+    return tags.reduce((currentMap, tag) => {
+      const { category } = tag;
+      const tags = currentMap.get(category) || [];
+      currentMap.set(category, [...tags, tag]);
+      return currentMap;
+    }, new Map<string, Tag[]>());
+  }, [tags]);
 
   return (
     <Accordion elevation={2} sx={sx}>
@@ -40,7 +49,8 @@ export const FullSearchForm: React.FC<Props> = ({ sx }) => {
       <AccordionDetails>
         {AllTagCategories.map((category) => {
           const onChange = onChangeCurried(category);
-          const categoryTags = tags.filter((tag) => tag.category === category);
+          // 型的にnullableだけど、実際は常にnon-null
+          const categoryTags = categoryToTags.get(category) || [];
           return (
             <TagSelector
               key={category}

--- a/src/components/organisms/FullSearchForm.tsx
+++ b/src/components/organisms/FullSearchForm.tsx
@@ -22,8 +22,7 @@ type Props = {
 export const FullSearchForm: React.FC<Props> = ({ sx }) => {
   const { state, dispatch } = React.useContext(FluxContext);
   const { tags } = state;
-  const { info, words } = state.search;
-  const { autocompleteOptions } = info;
+  const { nameAutocompleteOptions, words } = state.search;
   const onChangeCurried = React.useCallback(
     (target: SearchTarget) => (words: string[]) => {
       dispatch({ type: 'change-search-words', target, words });
@@ -55,7 +54,7 @@ export const FullSearchForm: React.FC<Props> = ({ sx }) => {
         <AutocompleteForm
           target="names"
           words={words.names}
-          autocompleteOptions={autocompleteOptions.names}
+          autocompleteOptions={nameAutocompleteOptions}
           onChange={onChangeCurried('names')}
         />
       </AccordionDetails>

--- a/src/components/templates/SearchTemplate.tsx
+++ b/src/components/templates/SearchTemplate.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import ships from '../../../ships.json';
+import tags from '../../../tags.json';
 import { FluxContext } from '../../flux/context';
 import { FullSearchForm } from '../organisms/FullSearchForm';
 import { SearchConditionSummary } from '../organisms/SearchConditionSummary';
@@ -15,8 +16,9 @@ export const SearchTemplate: React.FC = () => {
   const { state, dispatch } = React.useContext(FluxContext);
   React.useEffect(() => {
     dispatch({
-      type: 'load-ships-data',
-      ships: ships,
+      type: 'load-data',
+      ships,
+      tags,
     });
   }, [dispatch]);
 

--- a/src/flux/action.ts
+++ b/src/flux/action.ts
@@ -1,11 +1,13 @@
 import { SearchTarget } from '../lib/search-target';
 import { Ship } from '../lib/ship';
 import { SortOrder } from '../lib/sort-ships';
+import { Tag } from '../lib/tag';
 import { TagCategory } from '../lib/tag-category';
 
 type LoadShipsData = {
-  type: 'load-ships-data';
+  type: 'load-data';
   ships: Ship[];
+  tags: Tag[];
 };
 
 type ChangeSearchWordsAction = {

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -2,13 +2,14 @@ import { generateAutocompleteOptions } from '../lib/autocomplete';
 import { filterShips } from '../lib/filter-ships';
 import { Ship } from '../lib/ship';
 import { SortOrder, sortShips } from '../lib/sort-ships';
+import { Tag } from '../lib/tag';
 import { TagCategory } from '../lib/tag-category';
 import {
   onChangeSearchWords,
   onChangeShowAll,
   onChangeSortOrder,
   onClickTag,
-  onLoadShipsData,
+  onLoadData,
   onShowNextPage,
 } from './dispatch';
 import { State } from './state';
@@ -20,6 +21,7 @@ jest.mock('../lib/autocomplete');
 const baseState: Readonly<State> = {
   isReady: false,
   ships: [],
+  tags: [],
   search: {
     info: {
       autocompleteOptions: {
@@ -56,9 +58,10 @@ describe('onLoadShips', () => {
   };
   let nextState: State;
   const ships: Ship[] = [{} as Ship];
+  const tags: Tag[] = [{} as Tag];
 
   beforeEach(() => {
-    nextState = onLoadShipsData(currentState, ships);
+    nextState = onLoadData(currentState, ships, tags);
   });
 
   it('準備完了フラグが変更されている', () => {
@@ -67,6 +70,10 @@ describe('onLoadShips', () => {
 
   it('艦船が変更されている', () => {
     expect(nextState.ships).toEqual(ships);
+  });
+
+  it('タグ一覧が変更されている', () => {
+    expect(nextState.tags).toEqual(tags);
   });
 
   it('補完候補生成関数が呼び出されている', () => {

--- a/src/flux/dispatch.spec.ts
+++ b/src/flux/dispatch.spec.ts
@@ -1,4 +1,4 @@
-import { generateAutocompleteOptions } from '../lib/autocomplete';
+import { generateNameAutocompleteOptions } from '../lib/autocomplete';
 import { filterShips } from '../lib/filter-ships';
 import { Ship } from '../lib/ship';
 import { SortOrder, sortShips } from '../lib/sort-ships';
@@ -23,17 +23,7 @@ const baseState: Readonly<State> = {
   ships: [],
   tags: [],
   search: {
-    info: {
-      autocompleteOptions: {
-        categories: [],
-        types: [],
-        equipments: [],
-        abilities: [],
-        speeds: [],
-        ranges: [],
-        names: [],
-      },
-    },
+    nameAutocompleteOptions: [],
     words: {
       categories: [],
       types: [],
@@ -77,7 +67,7 @@ describe('onLoadShips', () => {
   });
 
   it('補完候補生成関数が呼び出されている', () => {
-    expect(generateAutocompleteOptions).toBeCalled();
+    expect(generateNameAutocompleteOptions).toBeCalled();
   });
 
   it('フィルタ関数が呼び出されている', () => {
@@ -160,7 +150,7 @@ describe('onChangeShowAll', () => {
       });
 
       it('補完候補生成関数が呼び出されている', () => {
-        expect(generateAutocompleteOptions).toBeCalled();
+        expect(generateNameAutocompleteOptions).toBeCalled();
       });
     }
   );

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -1,4 +1,4 @@
-import { generateAutocompleteOptions } from '../lib/autocomplete';
+import { generateNameAutocompleteOptions } from '../lib/autocomplete';
 import { filterShips } from '../lib/filter-ships';
 import { SearchTarget } from '../lib/search-target';
 import { Ship } from '../lib/ship';
@@ -10,7 +10,10 @@ import { State } from './state';
 export const onLoadData = (state: State, ships: Ship[], tags: Tag[]): State => {
   const { search } = state;
   const { showAll, words } = search;
-  const autocompleteOptions = generateAutocompleteOptions(ships, showAll);
+  const nameAutocompleteOptions = generateNameAutocompleteOptions(
+    ships,
+    showAll
+  );
   const results = filterShips(ships, words, showAll);
   return {
     ...state,
@@ -19,11 +22,7 @@ export const onLoadData = (state: State, ships: Ship[], tags: Tag[]): State => {
     tags,
     search: {
       ...search,
-      info: {
-        ...search.info,
-        autocompleteOptions,
-      },
-      words,
+      nameAutocompleteOptions,
       results,
       page: 1,
     },
@@ -55,17 +54,17 @@ export const onChangeSearchWords = (
 
 export const onChangeShowAll = (state: State, showAll: boolean): State => {
   const { ships, search } = state;
-  const { words, info } = search;
+  const { words } = search;
   const results = filterShips(ships, words, showAll);
-  const autocompleteOptions = generateAutocompleteOptions(ships, showAll);
+  const nameAutocompleteOptions = generateNameAutocompleteOptions(
+    ships,
+    showAll
+  );
   return {
     ...state,
     search: {
       ...search,
-      info: {
-        ...info,
-        autocompleteOptions,
-      },
+      nameAutocompleteOptions,
       showAll,
       results,
       page: 1,

--- a/src/flux/dispatch.ts
+++ b/src/flux/dispatch.ts
@@ -3,10 +3,11 @@ import { filterShips } from '../lib/filter-ships';
 import { SearchTarget } from '../lib/search-target';
 import { Ship } from '../lib/ship';
 import { SortOrder, sortShips } from '../lib/sort-ships';
+import { Tag } from '../lib/tag';
 import { TagCategory } from '../lib/tag-category';
 import { State } from './state';
 
-export const onLoadShipsData = (state: State, ships: Ship[]): State => {
+export const onLoadData = (state: State, ships: Ship[], tags: Tag[]): State => {
   const { search } = state;
   const { showAll, words } = search;
   const autocompleteOptions = generateAutocompleteOptions(ships, showAll);
@@ -15,6 +16,7 @@ export const onLoadShipsData = (state: State, ships: Ship[]): State => {
     ...state,
     isReady: true,
     ships,
+    tags,
     search: {
       ...search,
       info: {

--- a/src/flux/reducer.spec.ts
+++ b/src/flux/reducer.spec.ts
@@ -4,7 +4,7 @@ import {
   onChangeShowAll,
   onChangeSortOrder,
   onClickTag,
-  onLoadShipsData,
+  onLoadData,
   onShowNextPage,
 } from './dispatch';
 import { reducer } from './reducer';
@@ -17,7 +17,7 @@ describe('reducer', () => {
 
   describe.each`
     type                     | method
-    ${'load-ships-data'}     | ${onLoadShipsData}
+    ${'load-data'}           | ${onLoadData}
     ${'change-search-words'} | ${onChangeSearchWords}
     ${'change-show-all'}     | ${onChangeShowAll}
     ${'change-sort-order'}   | ${onChangeSortOrder}

--- a/src/flux/reducer.ts
+++ b/src/flux/reducer.ts
@@ -6,15 +6,15 @@ import {
   onChangeShowAll,
   onChangeSortOrder,
   onClickTag,
-  onLoadShipsData,
+  onLoadData,
   onShowNextPage,
 } from './dispatch';
 import { State } from './state';
 
 export const reducer: Reducer<State, Action> = (state, action) => {
   switch (action.type) {
-    case 'load-ships-data':
-      return onLoadShipsData(state, action.ships);
+    case 'load-data':
+      return onLoadData(state, action.ships, action.tags);
     case 'change-search-words':
       return onChangeSearchWords(state, action.target, action.words);
     case 'change-show-all':

--- a/src/flux/state.ts
+++ b/src/flux/state.ts
@@ -1,15 +1,10 @@
-import { AutocompleteOptions } from '../lib/autocomplete';
 import { SearchWords } from '../lib/filter-ships';
 import { Ship } from '../lib/ship';
 import { SortOrder } from '../lib/sort-ships';
 import { Tag } from '../lib/tag';
 
-type SearchInfoState = {
-  autocompleteOptions: AutocompleteOptions;
-};
-
 type SearchState = {
-  info: SearchInfoState;
+  nameAutocompleteOptions: string[];
   words: SearchWords;
   showAll: boolean;
   sortOrder: SortOrder;
@@ -29,17 +24,7 @@ export const initialState: State = {
   ships: [],
   tags: [],
   search: {
-    info: {
-      autocompleteOptions: {
-        categories: [],
-        types: [],
-        equipments: [],
-        abilities: [],
-        speeds: [],
-        ranges: [],
-        names: [],
-      },
-    },
+    nameAutocompleteOptions: [],
     words: {
       categories: [],
       types: [],

--- a/src/flux/state.ts
+++ b/src/flux/state.ts
@@ -2,6 +2,7 @@ import { AutocompleteOptions } from '../lib/autocomplete';
 import { SearchWords } from '../lib/filter-ships';
 import { Ship } from '../lib/ship';
 import { SortOrder } from '../lib/sort-ships';
+import { Tag } from '../lib/tag';
 
 type SearchInfoState = {
   autocompleteOptions: AutocompleteOptions;
@@ -19,12 +20,14 @@ type SearchState = {
 export type State = {
   isReady: boolean;
   ships: Ship[];
+  tags: Tag[];
   search: SearchState;
 };
 
 export const initialState: State = {
   isReady: false,
   ships: [],
+  tags: [],
   search: {
     info: {
       autocompleteOptions: {

--- a/src/lib/autocomplete/generate.spec.ts
+++ b/src/lib/autocomplete/generate.spec.ts
@@ -1,75 +1,43 @@
 import { Ship } from '../ship';
-import { generateAutocompleteOptions } from './generate';
+import { generateNameAutocompleteOptions } from './generate';
 
 describe('generateAutocompleteOptions', () => {
   const ships: Ship[] = [
     {
       name: 'Alpha',
-      category: 'category-one',
-      type: 'type-one',
-      speed: 'slow',
-      range: 'long',
-      equipments: ['abc', 'def'],
-      abilities: ['あいうえお'],
       showDefault: true,
     } as Ship,
     {
       name: 'Beta',
-      category: 'category-two',
-      type: 'type-two',
-      speed: 'fast',
-      range: 'middle',
-      equipments: ['def'],
-      abilities: ['かきくけこ'],
       showDefault: true,
     } as Ship,
     {
       name: 'Gamma',
-      category: 'category-one',
-      type: 'type-one',
-      speed: 'super-fast',
-      range: 'short',
-      equipments: ['def', 'ghi'],
-      abilities: ['かきくけこ'],
       showDefault: false,
     } as Ship,
     {
       name: 'Delta',
-      category: 'category-three',
-      type: 'type-three',
-      speed: 'fast',
-      range: 'short',
-      equipments: [],
-      abilities: ['さしすせそ'],
       showDefault: false,
     } as Ship,
   ];
 
   describe('デフォルト表示キャラのみが対象の場合', () => {
     it('デフォルト表示キャラの名前とタグの一覧を重複なく返す', () => {
-      expect(generateAutocompleteOptions(ships, false)).toEqual({
-        categories: ['category-one', 'category-two'],
-        types: ['type-one', 'type-two'],
-        equipments: ['abc', 'def'],
-        abilities: ['あいうえお', 'かきくけこ'],
-        speeds: ['fast', 'slow'],
-        ranges: ['long', 'middle'],
-        names: ['Alpha', 'Beta'],
-      });
+      expect(generateNameAutocompleteOptions(ships, false)).toEqual([
+        'Alpha',
+        'Beta',
+      ]);
     });
   });
 
   describe('全キャラのみが対象の場合', () => {
     it('全キャラの名前とタグの一覧を重複なく返す', () => {
-      expect(generateAutocompleteOptions(ships, true)).toEqual({
-        categories: ['category-one', 'category-three', 'category-two'],
-        types: ['type-one', 'type-three', 'type-two'],
-        equipments: ['abc', 'def', 'ghi'],
-        abilities: ['あいうえお', 'かきくけこ', 'さしすせそ'],
-        speeds: ['fast', 'slow', 'super-fast'],
-        ranges: ['long', 'middle', 'short'],
-        names: ['Alpha', 'Beta', 'Gamma', 'Delta'],
-      });
+      expect(generateNameAutocompleteOptions(ships, true)).toEqual([
+        'Alpha',
+        'Beta',
+        'Gamma',
+        'Delta',
+      ]);
     });
   });
 });

--- a/src/lib/autocomplete/generate.ts
+++ b/src/lib/autocomplete/generate.ts
@@ -1,28 +1,10 @@
 import { Ship } from '../ship';
-import { AutocompleteOptions } from './option';
 
-const uniqueAndSortTagLabels = (tagLabels: string[]): string[] => {
-  return Array.from(new Set(tagLabels)).sort();
-};
-
-export const generateAutocompleteOptions = (
+export const generateNameAutocompleteOptions = (
   ships: Ship[],
   showAll: boolean
-): AutocompleteOptions => {
-  const shipsShown = ships.filter(({ showDefault }) => showAll || showDefault);
-  return {
-    categories: uniqueAndSortTagLabels(
-      shipsShown.map(({ category }) => category)
-    ),
-    types: uniqueAndSortTagLabels(shipsShown.map(({ type }) => type)),
-    equipments: uniqueAndSortTagLabels(
-      shipsShown.flatMap(({ equipments }) => equipments)
-    ),
-    abilities: uniqueAndSortTagLabels(
-      shipsShown.flatMap(({ abilities }) => abilities)
-    ),
-    speeds: uniqueAndSortTagLabels(shipsShown.map(({ speed }) => speed)),
-    ranges: uniqueAndSortTagLabels(shipsShown.map(({ range }) => range)),
-    names: shipsShown.map(({ name }) => name),
-  };
+): string[] => {
+  return ships
+    .filter(({ showDefault }) => showAll || showDefault)
+    .map(({ name }) => name);
 };

--- a/src/lib/autocomplete/index.ts
+++ b/src/lib/autocomplete/index.ts
@@ -1,3 +1,2 @@
 export * from './compare';
 export * from './generate';
-export * from './option';

--- a/src/lib/autocomplete/option.ts
+++ b/src/lib/autocomplete/option.ts
@@ -1,3 +1,0 @@
-import { SearchTarget } from '../search-target';
-
-export type AutocompleteOptions = Record<SearchTarget, string[]>;

--- a/src/lib/tag.ts
+++ b/src/lib/tag.ts
@@ -1,0 +1,5 @@
+export type Tag = {
+  label: string;
+  category: string;
+  subCategory?: string;
+};

--- a/src/test-utils/flux.tsx
+++ b/src/test-utils/flux.tsx
@@ -5,6 +5,7 @@ import tags from '../../tags.json';
 import { FluxContext } from '../flux/context';
 import { reducer } from '../flux/reducer';
 import { State } from '../flux/state';
+import { generateNameAutocompleteOptions } from '../lib/autocomplete';
 import { SortOrder } from '../lib/sort-ships';
 
 export const initialTestState: State = {
@@ -12,9 +13,7 @@ export const initialTestState: State = {
   ships,
   tags,
   search: {
-    nameAutocompleteOptions: ships
-      .filter(({ showDefault }) => showDefault)
-      .map(({ name }) => name),
+    nameAutocompleteOptions: generateNameAutocompleteOptions(ships, false),
     words: {
       categories: [],
       types: [],

--- a/src/test-utils/flux.tsx
+++ b/src/test-utils/flux.tsx
@@ -5,7 +5,6 @@ import tags from '../../tags.json';
 import { FluxContext } from '../flux/context';
 import { reducer } from '../flux/reducer';
 import { State } from '../flux/state';
-import { generateAutocompleteOptions } from '../lib/autocomplete';
 import { SortOrder } from '../lib/sort-ships';
 
 export const initialTestState: State = {
@@ -13,9 +12,9 @@ export const initialTestState: State = {
   ships,
   tags,
   search: {
-    info: {
-      autocompleteOptions: generateAutocompleteOptions(ships, false),
-    },
+    nameAutocompleteOptions: ships
+      .filter(({ showDefault }) => showDefault)
+      .map(({ name }) => name),
     words: {
       categories: [],
       types: [],

--- a/src/test-utils/flux.tsx
+++ b/src/test-utils/flux.tsx
@@ -1,6 +1,7 @@
 import React, { useReducer } from 'react';
 
 import ships from '../../ships.json';
+import tags from '../../tags.json';
 import { FluxContext } from '../flux/context';
 import { reducer } from '../flux/reducer';
 import { State } from '../flux/state';
@@ -10,6 +11,7 @@ import { SortOrder } from '../lib/sort-ships';
 export const initialTestState: State = {
   isReady: true,
   ships,
+  tags,
   search: {
     info: {
       autocompleteOptions: generateAutocompleteOptions(ships, false),

--- a/tags.json
+++ b/tags.json
@@ -1,0 +1,439 @@
+[
+  {
+    "label": "戦艦級",
+    "category": "categories"
+  },
+  {
+    "label": "航空母艦",
+    "category": "categories"
+  },
+  {
+    "label": "重巡級",
+    "category": "categories"
+  },
+  {
+    "label": "軽巡級",
+    "category": "categories"
+  },
+  {
+    "label": "駆逐艦",
+    "category": "categories"
+  },
+  {
+    "label": "海防艦",
+    "category": "categories"
+  },
+  {
+    "label": "潜水艦",
+    "category": "categories"
+  },
+  {
+    "label": "補助艦艇",
+    "category": "categories"
+  },
+  {
+    "label": "戦艦",
+    "category": "types",
+    "subCategory": "戦艦級"
+  },
+  {
+    "label": "航空戦艦",
+    "category": "types",
+    "subCategory": "戦艦級"
+  },
+  {
+    "label": "正規空母",
+    "category": "types",
+    "subCategory": "航空母艦"
+  },
+  {
+    "label": "軽空母",
+    "category": "types",
+    "subCategory": "航空母艦"
+  },
+  {
+    "label": "装甲空母",
+    "category": "types",
+    "subCategory": "航空母艦"
+  },
+  {
+    "label": "重巡洋艦",
+    "category": "types",
+    "subCategory": "重巡級"
+  },
+  {
+    "label": "航空巡洋艦",
+    "category": "types",
+    "subCategory": "重巡級"
+  },
+  {
+    "label": "軽巡洋艦",
+    "category": "types",
+    "subCategory": "軽巡級"
+  },
+  {
+    "label": "重雷装巡洋艦",
+    "category": "types",
+    "subCategory": "軽巡級"
+  },
+  {
+    "label": "練習巡洋艦",
+    "category": "types",
+    "subCategory": "軽巡級"
+  },
+  {
+    "label": "駆逐艦",
+    "category": "types",
+    "subCategory": "駆逐艦"
+  },
+  {
+    "label": "海防艦",
+    "category": "types",
+    "subCategory": "海防艦"
+  },
+  {
+    "label": "潜水艦",
+    "category": "types",
+    "subCategory": "潜水艦"
+  },
+  {
+    "label": "潜水空母",
+    "category": "types",
+    "subCategory": "潜水艦"
+  },
+  {
+    "label": "水上機母艦",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "補給艦",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "特務艦",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "灯台補給船",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "南極観測船",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "特設護衛空母",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "揚陸艦",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "潜水母艦",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "工作艦",
+    "category": "types",
+    "subCategory": "補助艦艇"
+  },
+  {
+    "label": "艦上戦闘機",
+    "category": "equipments",
+    "subCategory": "艦上機"
+  },
+  {
+    "label": "艦上攻撃機",
+    "category": "equipments",
+    "subCategory": "艦上機"
+  },
+  {
+    "label": "艦上爆撃機",
+    "category": "equipments",
+    "subCategory": "艦上機"
+  },
+  {
+    "label": "噴式爆撃機",
+    "category": "equipments",
+    "subCategory": "艦上機"
+  },
+  {
+    "label": "艦上偵察機",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "水上偵察機",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "水上戦闘機",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "水上爆撃機",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "回転翼機",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "対潜哨戒機",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "大型飛行艇",
+    "category": "equipments",
+    "subCategory": "水上機"
+  },
+  {
+    "label": "小口径主砲",
+    "category": "equipments",
+    "subCategory": "主砲"
+  },
+  {
+    "label": "中口径主砲",
+    "category": "equipments",
+    "subCategory": "主砲"
+  },
+  {
+    "label": "大口径主砲",
+    "category": "equipments",
+    "subCategory": "主砲"
+  },
+  {
+    "label": "副砲",
+    "category": "equipments",
+    "subCategory": "副砲・機銃"
+  },
+  {
+    "label": "対空機銃",
+    "category": "equipments",
+    "subCategory": "副砲・機銃"
+  },
+  {
+    "label": "増設副砲",
+    "category": "equipments",
+    "subCategory": "副砲・機銃"
+  },
+  {
+    "label": "魚雷",
+    "category": "equipments",
+    "subCategory": "魚雷"
+  },
+  {
+    "label": "甲標的",
+    "category": "equipments",
+    "subCategory": "魚雷"
+  },
+  {
+    "label": "潜水艦魚雷",
+    "category": "equipments",
+    "subCategory": "魚雷"
+  },
+  {
+    "label": "小型ソナー",
+    "category": "equipments",
+    "subCategory": "対潜装備"
+  },
+  {
+    "label": "大型ソナー",
+    "category": "equipments",
+    "subCategory": "対潜装備"
+  },
+  {
+    "label": "爆雷",
+    "category": "equipments",
+    "subCategory": "対潜装備"
+  },
+  {
+    "label": "爆雷投射機",
+    "category": "equipments",
+    "subCategory": "対潜装備"
+  },
+  {
+    "label": "小型電探",
+    "category": "equipments",
+    "subCategory": "電探"
+  },
+  {
+    "label": "大型電探",
+    "category": "equipments",
+    "subCategory": "電探"
+  },
+  {
+    "label": "増設電探",
+    "category": "equipments",
+    "subCategory": "電探"
+  },
+  {
+    "label": "ドラム缶",
+    "category": "equipments",
+    "subCategory": "輸送"
+  },
+  {
+    "label": "大発動艇",
+    "category": "equipments",
+    "subCategory": "輸送"
+  },
+  {
+    "label": "特二式内火艇",
+    "category": "equipments",
+    "subCategory": "輸送"
+  },
+  {
+    "label": "洋上補給",
+    "category": "equipments",
+    "subCategory": "輸送"
+  },
+  {
+    "label": "三式弾",
+    "category": "equipments",
+    "subCategory": "強化弾"
+  },
+  {
+    "label": "徹甲弾",
+    "category": "equipments",
+    "subCategory": "強化弾"
+  },
+  {
+    "label": "増設バルジ(中型艦)",
+    "category": "equipments",
+    "subCategory": "増設バルジ"
+  },
+  {
+    "label": "増設バルジ(大型艦)",
+    "category": "equipments",
+    "subCategory": "増設バルジ"
+  },
+  {
+    "label": "探照灯",
+    "category": "equipments",
+    "subCategory": "夜戦装備"
+  },
+  {
+    "label": "大型探照灯",
+    "category": "equipments",
+    "subCategory": "夜戦装備"
+  },
+  {
+    "label": "照明弾",
+    "category": "equipments",
+    "subCategory": "夜戦装備"
+  },
+  {
+    "label": "機関部強化",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "応急修理要員",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "艦艇修理施設",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "艦隊司令部施設",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "航空要員",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "甲板要員",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "高射装置",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "対地装備",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "陸戦部隊",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "熟練見張員",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "発煙装置",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "潜水艦搭載電探",
+    "category": "equipments",
+    "subCategory": "その他"
+  },
+  {
+    "label": "特殊攻撃",
+    "category": "abilities"
+  },
+  {
+    "label": "無条件先制対潜",
+    "category": "abilities"
+  },
+  {
+    "label": "夜間作戦空母",
+    "category": "abilities"
+  },
+  {
+    "label": "専用対空カットイン",
+    "category": "abilities"
+  },
+  {
+    "label": "高速",
+    "category": "speeds"
+  },
+  {
+    "label": "低速",
+    "category": "speeds"
+  },
+  {
+    "label": "短射程",
+    "category": "ranges"
+  },
+  {
+    "label": "中射程",
+    "category": "ranges"
+  },
+  {
+    "label": "長射程",
+    "category": "ranges"
+  },
+  {
+    "label": "超長射程",
+    "category": "ranges"
+  }
+]


### PR DESCRIPTION
- タグをサブカテゴリごとにグルーピングする (Resolve #124)
    - 内部データをソートしてあるので自動でいい感じのソートもされている
- 補完候補の生成を艦名だけにする
    - #140 のclose時点でタグの補完候補生成は不要になっていた
    - 合わせて補完候補まわりをリファクタ

![gokan-search-git-group-tags-roadagain vercel app_(HD)](https://github.com/Roadagain/gokan-search/assets/7444623/2bd752ac-279a-49d0-abf1-80b21a2fff9c)